### PR TITLE
feat: set location via command line parameter

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -8,30 +8,44 @@ const dateFormat = require('dateformat');
 const inquirer = require('inquirer');
 const newGatsbyPost = require('new-gatsby-post');
 
+// eslint-disable-next-line prefer-destructuring
+const argv = require('yargs')
+  .usage('Usage: $0 [options]')
+  .alias('l', 'location')
+  .nargs('l', 1)
+  .describe('l', 'New post location')
+  .help('h')
+  .alias('h', 'help').argv;
+
+const prompt = [
+  {
+    type: 'input',
+    name: 'title',
+    message: 'Title:',
+    validate: x => (x.length > 0 ? true : '`Title` is required'),
+  },
+  {
+    type: 'input',
+    name: 'date',
+    message: 'Date (yyyy-mm-dd):',
+    default: dateFormat(Date.now(), 'isoDate'),
+  },
+];
+
+if (!argv.location) {
+  prompt.unshift({
+    type: 'input',
+    name: 'location',
+    message: 'Location:',
+    default: normalize('./src/pages/blog'),
+  });
+}
+
 inquirer
-  .prompt([
-    {
-      type: 'input',
-      name: 'location',
-      message: 'Location:',
-      default: normalize('./src/pages/blog'),
-    },
-    {
-      type: 'input',
-      name: 'title',
-      message: 'Title:',
-      validate: x => (x.length > 0 ? true : '`Title` is required'),
-    },
-    {
-      type: 'input',
-      name: 'date',
-      message: 'Date (yyyy-mm-dd):',
-      default: dateFormat(Date.now(), 'isoDate'),
-    },
-  ])
+  .prompt(prompt)
   .then(answers =>
     newGatsbyPost(answers.title, {
-      location: answers.location,
+      location: argv.location || answers.location,
       date: answers.date,
     })
   )

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "dateformat": "^3.0.2",
     "inquirer": "^5.0.0",
     "log-symbols": "^2.1.0",
-    "new-gatsby-post": "^1.0.3"
+    "new-gatsby-post": "^1.0.3",
+    "yargs": "^11.0.0"
   },
   "devDependencies": {
     "dedent": "^0.7.0",

--- a/test.js
+++ b/test.js
@@ -40,7 +40,7 @@ it('creates new blog post with --location parameter', async () => {
   expect(content).toBe(dedent`
     ---
     date: "2013-08-06"
-    title: "I did not try"
+    title: "I Did Not Try"
     ---\n
   `);
 });
@@ -60,7 +60,7 @@ it('creates new blog post with -l parameter', async () => {
   expect(content).toBe(dedent`
     ---
     date: "2013-08-07"
-    title: "I gave up"
+    title: "I Gave Up"
     ---\n
   `);
 });

--- a/test.js
+++ b/test.js
@@ -24,3 +24,43 @@ it('creates new blog post', async () => {
     ---\n
   `);
 });
+
+it('creates new blog post with --location parameter', async () => {
+  expect.assertions(1);
+
+  await run(
+    ['./cli.js', '--location', './src/pages/blog'],
+    ['I did not try', ENTER, '2013-08-06', ENTER]
+  );
+  const content = await readFile(
+    './src/pages/blog/2013-08-06-i-did-not-try/index.md',
+    'utf8'
+  );
+
+  expect(content).toBe(dedent`
+    ---
+    date: "2013-08-06"
+    title: "I did not try"
+    ---\n
+  `);
+});
+
+it('creates new blog post with -l parameter', async () => {
+  expect.assertions(1);
+
+  await run(
+    ['./cli.js', '-l', './src/pages/blog'],
+    ['I gave up', ENTER, '2013-08-07', ENTER]
+  );
+  const content = await readFile(
+    './src/pages/blog/2013-08-07-i-gave-up/index.md',
+    'utf8'
+  );
+
+  expect(content).toBe(dedent`
+    ---
+    date: "2013-08-07"
+    title: "I gave up"
+    ---\n
+  `);
+});


### PR DESCRIPTION
The post location is static and in my opinion it does not make sense to type it again and again when it does not equal the default value (mine is `./src/pages`). Added command line option `--location` that can be used in `package.json` script for example.

Note regarding the disabled eslint rule - I find it quite frustrating that xo and prettier force me to change quite readable `yargs` example code to something less readable. Also finding ways how to overcome their errors it wasted time for me. Xo forces me to destructure argv variable but when I do that the yargs doesn't work for some reason. So I used the `eslint-disable-next-line`. Then prettier forced me to put final `.argv` to the same line as `.alias` - not sure why. :-(